### PR TITLE
WIFI-845: Support Kubernetes Deployment Versioning

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+    schedule:
+      # runs at cronjob at 5AM
+      - cron:  '00 09 * * *'
+
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*
@@ -48,7 +52,10 @@ jobs:
 
       - name: Build image
         run: docker build . --file Dockerfile --tag image
-        
+
+      - name: Set current date as env variable
+        run: echo "::set-env name=TIMESTAMP::$(date +'%Y-%m-%d')"        
+
       - name: Login to Docker Hub
         env:
           DOCKER_PASSWORD: ${{ secrets.REPO_PASSWORD }}
@@ -75,4 +82,7 @@ jobs:
           echo VERSION=$VERSION
 
           docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION-$TIMESTAMP
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -85,4 +85,4 @@ jobs:
           docker push $IMAGE_ID:$VERSION
 
           docker tag image $IMAGE_ID:$VERSION-$TIMESTAMP
-          docker push $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION-$TIMESTAMP


### PR DESCRIPTION
JIRA: WIFI-845(https://telecominfraproject.atlassian.net/browse/WIFI-845)

## Description
Added timestamp tags to the docker images and nightly build cronjob. After this change, 2 docker images (latest tag and latest-timestamp tag) would get pushed to the artifactory.