### PR TITLE
bugfix/NETEXP-1335: Passpoint profile childProfileIds fix

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -522,10 +522,10 @@ const resolvers = {
       return result && result.value2;
     },
     associatedSsidProfiles: ({ details }, args, { dataSources }) => {
-      const { associatedAccessSsidProfileIds, osuSsidProfileId } = details;
+      const { associatedAccessSsidProfileIds } = details;
       return (
         associatedAccessSsidProfileIds &&
-        dataSources.api.getProfilesById([...associatedAccessSsidProfileIds, osuSsidProfileId])
+        dataSources.api.getProfilesById([...associatedAccessSsidProfileIds])
       );
     },
   },

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -525,7 +525,7 @@ const resolvers = {
       const { associatedAccessSsidProfileIds } = details;
       return (
         associatedAccessSsidProfileIds &&
-        dataSources.api.getProfilesById([...associatedAccessSsidProfileIds])
+        dataSources.api.getProfilesById(associatedAccessSsidProfileIds)
       );
     },
   },

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -521,6 +521,13 @@ const resolvers = {
 
       return result && result.value2;
     },
+    associatedSsidProfiles: ({ details }, args, { dataSources }) => {
+      const { associatedAccessSsidProfileIds, osuSsidProfileId } = details;
+      return (
+        associatedAccessSsidProfileIds &&
+        dataSources.api.getProfilesById([...associatedAccessSsidProfileIds, osuSsidProfileId])
+      );
+    },
   },
   ClientSession: {
     id: ({ macAddress }) => macAddress.addressAsString,

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -528,6 +528,10 @@ const resolvers = {
         dataSources.api.getProfilesById(associatedAccessSsidProfileIds)
       );
     },
+    osuSsidProfile: ({ details }, args, { dataSources }) => {
+      const { osuSsidProfileId } = details;
+      return osuSsidProfileId && dataSources.api.getProfile(osuSsidProfileId);
+    },
   },
   ClientSession: {
     id: ({ macAddress }) => macAddress.addressAsString,

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -522,15 +522,16 @@ const resolvers = {
       return result && result.value2;
     },
     associatedSsidProfiles: ({ details }, args, { dataSources }) => {
-      const { associatedAccessSsidProfileIds } = details;
       return (
-        associatedAccessSsidProfileIds &&
-        dataSources.api.getProfilesById(associatedAccessSsidProfileIds)
+        details &&
+        details.associatedAccessSsidProfileIds &&
+        dataSources.api.getProfilesById(details.associatedAccessSsidProfileIds)
       );
     },
     osuSsidProfile: ({ details }, args, { dataSources }) => {
-      const { osuSsidProfileId } = details;
-      return osuSsidProfileId && dataSources.api.getProfile(osuSsidProfileId);
+      return (
+        details && details.osuSsidProfileId && dataSources.api.getProfile(details.osuSsidProfileId)
+      );
     },
   },
   ClientSession: {

--- a/src/schema.js
+++ b/src/schema.js
@@ -231,6 +231,7 @@ const typeDefs = gql`
     lastModifiedTimestamp: String
     equipmentCount: Int
     details: JSONObject
+    associatedSsidProfiles: [Profile]
   }
 
   type ProfilePagination {

--- a/src/schema.js
+++ b/src/schema.js
@@ -232,6 +232,7 @@ const typeDefs = gql`
     equipmentCount: Int
     details: JSONObject
     associatedSsidProfiles: [Profile]
+    osuSsidProfile: Profile
   }
 
   type ProfilePagination {


### PR DESCRIPTION
JIRA: [NETEXP-1335](https://connectustechnologies.atlassian.net/browse/NETEXP-1335)

## Description
*Summary of this PR*
Fixed passpoint point profile creation and update:  Update all associated SSIDs profiles by putting the Passpoint profile ID in the `childrenIds` instead of passing in SSID profile as `childrenIds` of Passpoint profile itself
